### PR TITLE
修复 Linux(x86_64) 下的编译错误

### DIFF
--- a/cmake/Findminizip.cmake
+++ b/cmake/Findminizip.cmake
@@ -1,0 +1,114 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+Findminizip
+-----------
+
+Find the minizip include directory and library.
+
+Use this module by invoking find_package with the form::
+
+.. code-block:: cmake
+
+  find_package(minizip
+    [REQUIRED]             # Fail with error if minizip is not found
+  )
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+.. variable:: minizip::minizip
+
+  Imported target for using the minizip library, if found.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+.. variable:: minizip_FOUND
+
+  Set to true if minizip library found, otherwise false or undefined.
+
+.. variable:: minizip_INCLUDE_DIRS
+
+  Paths to include directories listed in one variable for use by minizip client.
+
+.. variable:: minizip_LIBRARIES
+
+  Paths to libraries to linked against to use minizip.
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+For users who wish to edit and control the module behavior, this module
+reads hints about search locations from the following variables::
+
+.. variable:: minizip_INCLUDE_DIR
+
+  Path to minizip include directory with ``minizip/unzip.h`` header.
+
+.. variable:: minizip_LIBRARY
+
+  Path to minizip library to be linked.
+
+NOTE: The variables above should not usually be used in CMakeLists.txt files!
+
+#]=======================================================================]
+
+### Find library ##############################################################
+
+if(NOT minizip_LIBRARY)
+    find_library(minizip_LIBRARY_RELEASE NAMES minizip)
+    find_library(minizip_LIBRARY_DEBUG NAMES minizipd)
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(minizip)
+else()
+    file(TO_CMAKE_PATH "${minizip_LIBRARY}" minizip_LIBRARY)
+endif()
+
+### Find include directory ####################################################
+find_path(minizip_INCLUDE_DIR NAMES minizip/unzip.h)
+
+### Set result variables ######################################################
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(minizip DEFAULT_MSG
+        minizip_LIBRARY minizip_INCLUDE_DIR)
+
+set(minizip_INCLUDE_DIR ${minizip_INCLUDE_DIR} CACHE PATH "minizip include dir hint")
+set(minizip_LIBRARY ${minizip_LIBRARY} CACHE FILEPATH "minizip library path hint")
+mark_as_advanced(minizip_INCLUDE_DIR minizip_LIBRARY)
+
+set(minizip_LIBRARIES ${minizip_LIBRARY})
+set(minizip_INCLUDE_DIRS ${minizip_INCLUDE_DIR})
+
+### Import targets ############################################################
+if(minizip_FOUND)
+    if(NOT TARGET minizip::minizip)
+        add_library(minizip::minizip UNKNOWN IMPORTED)
+        set_target_properties(minizip::minizip PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                INTERFACE_INCLUDE_DIRECTORIES "${minizip_INCLUDE_DIR}")
+
+        if(minizip_LIBRARY_RELEASE)
+            set_property(TARGET minizip::minizip APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(minizip::minizip PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${minizip_LIBRARY_RELEASE}")
+        endif()
+
+        if(minizip_LIBRARY_DEBUG)
+            set_property(TARGET minizip::minizip APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(minizip::minizip PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${minizip_LIBRARY_DEBUG}")
+        endif()
+
+        if(NOT minizip_LIBRARY_RELEASE AND NOT minizip_LIBRARY_DEBUG)
+            set_property(TARGET minizip::minizip APPEND PROPERTY
+                    IMPORTED_LOCATION "${minizip_LIBRARY}")
+        endif()
+    endif()
+endif()

--- a/components/bsa/zipfile.hpp
+++ b/components/bsa/zipfile.hpp
@@ -3,6 +3,8 @@
 
 #include <string.h>
 #include <istream>
+#include <fstream>
+#include <chrono>
 #include <mutex>
 
 #include <minizip/unzip.h>
@@ -81,10 +83,28 @@ namespace Bsa
             int hour = static_cast<int>((dosTime >> 11) & 0x1f);
             int minute = static_cast<int>((dosTime >> 5) & 0x3f);
             int second = static_cast<int>((dosTime & 0x1f) * 2);
+
+            #if __cplusplus >= 202002L
+
             auto st = std::chrono::sys_days{ std::chrono::year_month_day{
                 std::chrono::year{ year }, std::chrono::month{ month }, std::chrono::day{ day } } } +
                 std::chrono::hours{ hour } + std::chrono::minutes{ minute } + std::chrono::seconds{ second };
             return std::chrono::clock_cast<std::chrono::file_clock>(st);
+            #else
+            std::tm tm{};
+            tm.tm_year = year - 1900; 
+            tm.tm_mon = month - 1; 
+            tm.tm_mday = day;
+            tm.tm_hour = hour; 
+            tm.tm_min = minute; 
+            tm.tm_sec = second;
+            
+            auto sys_time = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+            return std::filesystem::file_time_type::clock::now() + 
+                   std::chrono::duration_cast<std::filesystem::file_time_type::duration>(
+                       sys_time - std::chrono::system_clock::now()
+                   );
+            #endif
         }
 
         static std::string filenameToStem(const char* filename)


### PR DESCRIPTION
在Linux上安装的`minizip`包似乎不带cmake文件,ai生成了一个

`components/bsa/zipfile.hpp`文件中的`dosToFileTime`函数编译时有报错,可能和C++的版本有关,也是ai生成的函数

另外我也测试了直接这样:
```
static std::filesystem::file_time_type dosToFileTime(uLong dosTime) {
    return std::filesystem::file_time_type{};
}
```
也可以成功编译.

在ubuntu 24.04下成功编译并运行,完整步骤如下:
```
sudo apt update
sudo apt install cmake software-properties-common minizip libminizip-dev
git clone
cd openmw

sudo ./CI/install_debian_deps.sh gcc openmw-deps openmw-deps-dynamic

mkdir build && cd build

cmake .. \
    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
    -D OPENMW_USE_SYSTEM_RECASTNAVIGATION=OFF \
    -D USE_SYSTEM_TINYXML=ON \
    -D minizip_LIBRARY=/usr/lib/x86_64-linux-gnu/libminizip.so.1.0.0

make -j${nproc}
```

编译完成之后运行`./openmw-launcher`即可启动,如果遇到中文不显示可以尝试:
1. 把仓库中的`files/openmw_reset.cfg`复制到`~/.config/openmw/openmw.cfg`
2. 生成`zh_CN.gbk`的locale(取消`/etc/locale.gen`文件中`zh_CN.GBK GBK`行的注释后运行`sudo locale-gen`)然后重新登录后运行启动器即可

我不是一个c++程序员,如果给您带来负担,很抱歉.